### PR TITLE
 jme3test.app.TestApplication hangs with LWJGL3 #1193

### DIFF
--- a/jme3-lwjgl3/src/main/java/com/jme3/system/lwjgl/LwjglWindow.java
+++ b/jme3-lwjgl3/src/main/java/com/jme3/system/lwjgl/LwjglWindow.java
@@ -479,7 +479,7 @@ public abstract class LwjglWindow extends LwjglContext implements Runnable {
         // NOTE: this is required for Mac OS X!
         mainThread = Thread.currentThread();
         mainThread.setName("jME3 Main");
-        run();
+        new Thread(this, "jME3 Main").start();
     }
 
     /**


### PR DESCRIPTION
LWJGL3-JME projects was doing a call that is blocking the current thread.  I changed it to match how LWJGL2-JME project launches the Context Window.